### PR TITLE
Import & reload pkg_resources for setuptools entry point discovery.

### DIFF
--- a/pyuwsgi/resources/bootstrap.py
+++ b/pyuwsgi/resources/bootstrap.py
@@ -1,6 +1,11 @@
 import os
 import sys
 
+if sys.version_info[0] >= 3:
+    from importlib import reload
+else:
+    from imp import reload
+
 
 def activate_pex():
   sys.stderr.write('[pex_uwsgi] bootstrapping..\n')
@@ -42,6 +47,10 @@ def activate_pex():
     pex_info = PexInfo.from_pex(entry_point)
     env = PEXEnvironment(entry_point, pex_info)
     env.activate()
+
+  # import & reload in our newly bootstrapped environment
+  import pkg_resources
+  reload(pkg_resources)
 
   sys.stderr.write('[pex_uwsgi] sys.path=%s\n\n' % sys.path)
   return

--- a/pyuwsgi/resources/bootstrap.py
+++ b/pyuwsgi/resources/bootstrap.py
@@ -2,9 +2,9 @@ import os
 import sys
 
 if sys.version_info[0] >= 3:
-    from importlib import reload
+  from importlib import reload
 else:
-    from imp import reload
+  from imp import reload
 
 
 def activate_pex():


### PR DESCRIPTION
Hiya hiya,

Noticed when using a variation of this uwsgi boostrapping goodness that setuptools registered entry points were being ignored.

Not sure if this is an artifact of the way that pex ships a pkg_resources module, or if it's a bug in pex (in which case, let's follow up there) but for the time being we do something like this PR.

example:

```
In [7]: import sys, os
In [8]: entry_point = '/export/content/linkedin/bin/deployment-tools.pex'
In [9]: sys.path.insert(0, entry_point)
In [10]: sys.path.insert(0, os.path.abspath(os.path.join(entry_point, '.bootstrap')))
In [11]: from _pex import pex_bootstrapper
In [12]: pex_bootstrapper.bootstrap_pex_env(entry_point)
In [13]: import pkg_resources
In [14]: [e for e in pkg_resources.iter_entry_points('range.plugins')]
Out[14]: []
In [15]: reload(pkg_resources)
Out[15]: <module 'pkg_resources' from '/export/content/linkedin/bin/deployment-tools.pex/.bootstrap/pkg_resources.py'>
In [16]: [e for e in pkg_resources.iter_entry_points('range.plugins')]
Out[16]: [EntryPoint.parse('topology = linkedin.topologyrangeplugin:FlatTopologyParser')]
```
